### PR TITLE
Properly print error message on missing value-object

### DIFF
--- a/test.py
+++ b/test.py
@@ -52,7 +52,7 @@ for needle in sorted(needles):
                 error("Needle '{}' includes a workaround tag but has no bug-ID in filename!".format(needle))
             break
         elif isinstance(p, dict) and p['name'] == 'workaround':
-            if p['value'] == '':
+            if p.get('value', '') == '':
                 error("Needle '{}' includes a workaround tag but has no reason in json file!".format(needle))
             break
 


### PR DESCRIPTION
https://github.com/os-autoinst/os-autoinst-needles-opensuse/commit/01f5bcb3aba4ae2f0c6f2fd4a023e1bd98e3c370 introduced a needle which we consider a `workaround`. This fixes the subsequent test to work even with this object missing and makes the script print a proper needle-path to the user.