### PR TITLE
Print expected regex for invalid timestamps in needle names

### DIFF
--- a/test.py
+++ b/test.py
@@ -25,16 +25,16 @@ for f in os.listdir(needledir):
 
 # Check for missing parts
 for needle in sorted(needles):
-    jsonfile = needledir / Path(needle + '.json')
-    pngfile = needledir / Path(needle + '.png')
+    jsonfile = needledir / Path(f"{needle}.json")
+    pngfile = needledir / Path(f"{needle}.png")
 
     # Check for file existence
     if not os.path.isfile(jsonfile):
-        error("Needle '{}' is missing its JSON file!".format(needle))
+        error(f"Needle '{needle}' is missing its JSON file!")
         continue # parsing the json makes no sense
 
     if not os.path.isfile(pngfile):
-        error("Needle '{}' is missing its PNG file!".format(needle))
+        error(f"Needle '{needle}' is missing its PNG file!")
 
     # Check JSON content
     n = {}
@@ -60,12 +60,12 @@ for needle in sorted(needles):
     # Check if multiple areas with type=click exist in the same needle
     area_count = len([a for a in n['area'] if a['type'] == 'click'])
     if area_count > 1:
-        error("Needle '{}' has {} areas with type=click while only one is allowed!".format(needle, area_count))
+        error(f"Needle '{needle}' has {area_count} areas with type=click but only one is allowed!")
 
     # Check if name contains timestamp
     timestamp = re.sub(r"_.*$", '', re.sub(r"[_-][0-9]{1,2}$", '', needle).split("-")[-1])
     if not timestamp.isnumeric() or len(timestamp) < 8 or int(timestamp) < 20130000:
-        error("Needle '{}' missing or invalid timestamp!".format(needle))
+        error(f"Needle '{needle}' missing or invalid timestamp!")
 
     # Check if needle contains duplicate tags
     if len(n['tags']) != len(set(n['tags'])):

--- a/test.py
+++ b/test.py
@@ -63,9 +63,10 @@ for needle in sorted(needles):
         error(f"Needle '{needle}' has {area_count} areas with type=click but only one is allowed!")
 
     # Check if name contains timestamp
-    timestamp = re.sub(r"_.*$", '', re.sub(r"[_-][0-9]{1,2}$", '', needle).split("-")[-1])
+    needle_regex = r"[_-][0-9]{1,2}$"
+    timestamp = re.sub(r"_.*$", '', re.sub(needle_regex, '', needle).split("-")[-1])
     if not timestamp.isnumeric() or len(timestamp) < 8 or int(timestamp) < 20130000:
-        error(f"Needle '{needle}' missing or invalid timestamp!")
+        error(f"Needle '{needle}' is not matching the expected format: `{needle_regex}`!")
 
     # Check if needle contains duplicate tags
     if len(n['tags']) != len(set(n['tags'])):

--- a/test.py
+++ b/test.py
@@ -4,9 +4,10 @@ import os
 import sys
 import re
 import json
+from pathlib import Path
 
-scriptdir = os.path.dirname(os.path.realpath(__file__))
-needledir = os.path.join(scriptdir, "..")
+scriptdir = Path(os.path.dirname(os.path.realpath(__file__)))
+needledir = scriptdir / Path("..")
 
 returncode = 0
 
@@ -24,8 +25,8 @@ for f in os.listdir(needledir):
 
 # Check for missing parts
 for needle in sorted(needles):
-    jsonfile = os.path.join(needledir, needle + '.json')
-    pngfile = os.path.join(needledir, needle + '.png')
+    jsonfile = needledir / Path(needle + '.json')
+    pngfile = needledir / Path(needle + '.png')
 
     # Check for file existence
     if not os.path.isfile(jsonfile):


### PR DESCRIPTION
The main improvement is https://github.com/os-autoinst/os-autoinst-needles-tests/commit/db82a8740d6245bf37f5114afe6921ba6a88a91e, all other commits are mainly because I had the file open already.

This will change the resulting output from:

```
$ tests/test.py
Needle 'firstrun-sl-micro-keylayout-en_US-20260624' includes a workaround tag but has no reason in json file!
Needle 'kgx-20260804-ppc64' missing or invalid timestamp!
```

to:

```
$ python test.py
Needle 'firstrun-sl-micro-keylayout-en_US-20260624' includes a workaround tag but has no reason in json file!
Needle 'kgx-20260804-ppc64' is not matching the expected format: `[_-][0-9]{1,2}$`!
```