### PR TITLE
Make missing timestamp errors easier to understand

### DIFF
--- a/test.py
+++ b/test.py
@@ -63,10 +63,10 @@ for needle in sorted(needles):
         error(f"Needle '{needle}' has {area_count} areas with type=click but only one is allowed!")
 
     # Check if name contains timestamp
-    needle_regex = r"[_-][0-9]{1,2}$"
-    timestamp = re.sub(r"_.*$", '', re.sub(needle_regex, '', needle).split("-")[-1])
+    regex_suffix = r"[_-][0-9]{1,2}$"
+    timestamp = re.sub(r"_.*$", '', re.sub(regex_suffix, '', needle).split("-")[-1])
     if not timestamp.isnumeric() or len(timestamp) < 8 or int(timestamp) < 20130000:
-        error(f"Needle '{needle}' is not matching the expected format: `{needle_regex}`!")
+        error(f"Needle '{needle}' has missing or invalid timestamp suffix (valid suffixes: -YYYYMMDD or -YYYYMMDD_n with n=0…99) at the end!")
 
     # Check if needle contains duplicate tags
     if len(n['tags']) != len(set(n['tags'])):


### PR DESCRIPTION
Don't print regex as it is only used to strip the suffix.
Fixes #9


```
Needle 'kgx-terminal-unfocused-20251113-ppc64' has missing or invalid timestamp suffix (e.g. -YYYYMMDD or -YYYYMMDD_n with n=1…99) at the end!
